### PR TITLE
drop -navigable to shorten initial description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **The open standard for project accessibility transparency, governance, and AI-assisted inclusion.**
 
-Just as `SECURITY.md` defines how to handle vulnerabilities, **`ACCESSIBILITY.md`** defines the inclusive state of a project. It is a human-navigable and machine-readable manifest that tracks a project’s commitment to accessibility (a11y) through metrics, guardrails, and automated enforcement.
+Just as `SECURITY.md` defines how to handle vulnerabilities, **`ACCESSIBILITY.md`** defines the inclusive state of a project. It is a human and machine-readable manifest that tracks a project’s commitment to accessibility (a11y) through metrics, guardrails, and automated enforcement.
 
 ---
 


### PR DESCRIPTION
suggested editorial edit: drop "navigable" as "human and machine-readable" is sufficient for a top level summary sentence, and leans a bit more human (readability not just navigability)