### PR TITLE
Fix broken markdown links causing Link Check CI failures

### DIFF
--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -20,7 +20,7 @@
 | Last reviewed | 2026-07-19 |
 
 The reusable starting point for other projects is
-[ACCESSIBILITY-template.md](ACCESSIBILITY-template.md). This file describes
+[ACCESSIBILITY-template.md](examples/ACCESSIBILITY-template.md). This file describes
 the commitments and limitations of this repository itself.
 
 ## 2. Commitment
@@ -50,7 +50,7 @@ We aim to:
 This commitment applies to:
 
 - the repository's Markdown, HTML, CSS, JavaScript, and Jekyll output;
-- [ACCESSIBILITY-template.md](ACCESSIBILITY-template.md);
+- [ACCESSIBILITY-template.md](examples/ACCESSIBILITY-template.md);
 - guidance and examples in [examples](examples/);
 - sample workflows, prompts, and configuration;
 - SVG, Mermaid, charts, tables, images, and other visual content;
@@ -525,7 +525,7 @@ Review this file and affected guidance:
 
 ## 18. Quick Reference
 
-- Reusable template: [ACCESSIBILITY-template.md](ACCESSIBILITY-template.md)
+- Reusable template: [ACCESSIBILITY-template.md](examples/ACCESSIBILITY-template.md)
 - Contribution overview: [CONTRIBUTING.md](CONTRIBUTING.md)
 - Detailed contributor guidance:
   [CONTRIBUTING_A11Y.md](examples/CONTRIBUTING_A11Y.md)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Just as `SECURITY.md` defines how to handle vulnerabilities, **`ACCESSIBILITY.md
 
 **New to this project?** Here's what you need:
 
-1. **Copy the template** → Start with [ACCESSIBILITY-template.md](./ACCESSIBILITY-template.md)
+1. **Copy the template** → Start with [ACCESSIBILITY-template.md](./examples/ACCESSIBILITY-template.md)
 2. **Add CI workflows** → Copy from [examples/](./examples/) directory
 3. **Configure AI agents** → Use [AGENTS.md](./AGENTS.md) as a guide
 4. **Read the framework** → Continue below to understand the approach
@@ -149,7 +149,7 @@ This repository provides templates and guidance to help you implement `ACCESSIBI
 ### Step 1: Add ACCESSIBILITY.md to your repository
 
 **Option A: Start with the template**
-1. Copy [ACCESSIBILITY-template.md](./ACCESSIBILITY-template.md) to your repository root
+1. Copy [ACCESSIBILITY-template.md](./examples/ACCESSIBILITY-template.md) to your repository root
 2. Rename it to `ACCESSIBILITY.md`
 3. Customize the sections to match your project's current state
 4. Link it from your `README.md`

--- a/examples/ACCESSIBILITY-template.md
+++ b/examples/ACCESSIBILITY-template.md
@@ -167,8 +167,8 @@ and arrange additional evaluation in proportion to risk.
 ## 6. Contributor Requirements
 
 Read `{{CONTRIBUTING_GUIDE_URL}}` before contributing. For this repository,
-see [Contributing](CONTRIBUTING.md) and the
-[Contributing Accessibility Guide](examples/CONTRIBUTING_A11Y.md).
+see [Contributing](../CONTRIBUTING.md) and the
+[Contributing Accessibility Guide](CONTRIBUTING_A11Y.md).
 
 Every contribution must:
 
@@ -261,7 +261,7 @@ Use this summary:
   temporary context closes.
 - Do not make static content focusable merely to expose it to screen readers.
 
-See [Keyboard Accessibility Best Practices](examples/KEYBOARD_ACCESSIBILITY_BEST_PRACTICES.md).
+See [Keyboard Accessibility Best Practices](KEYBOARD_ACCESSIBILITY_BEST_PRACTICES.md).
 
 ### Forms, errors, and status
 
@@ -283,7 +283,7 @@ See [Keyboard Accessibility Best Practices](examples/KEYBOARD_ACCESSIBILITY_BEST
 - Keep system, light, and dark options single-choice when a manual theme
   selector is provided.
 
-See [Light/Dark Mode Accessibility Best Practices](examples/LIGHT_DARK_MODE_ACCESSIBILITY_BEST_PRACTICES.md).
+See [Light/Dark Mode Accessibility Best Practices](LIGHT_DARK_MODE_ACCESSIBILITY_BEST_PRACTICES.md).
 
 ### Media, images, and data
 
@@ -294,7 +294,7 @@ See [Light/Dark Mode Accessibility Best Practices](examples/LIGHT_DARK_MODE_ACCE
   structured data.
 - Keep alternatives synchronized with the visual source.
 
-See [Charts and Graphs Accessibility Best Practices](examples/CHARTS_GRAPHS_ACCESSIBILITY_BEST_PRACTICES.md).
+See [Charts and Graphs Accessibility Best Practices](CHARTS_GRAPHS_ACCESSIBILITY_BEST_PRACTICES.md).
 
 ## 8. SVG, Mermaid, and Generated Output
 
@@ -316,7 +316,7 @@ or remove semantics.
   and test the post-sanitization result.
 - Do not treat an XML parser or optimizer as a security sanitizer.
 
-See [SVG Accessibility Best Practices](examples/SVG_ACCESSIBILITY_BEST_PRACTICES.md).
+See [SVG Accessibility Best Practices](SVG_ACCESSIBILITY_BEST_PRACTICES.md).
 
 ### Mermaid
 
@@ -334,9 +334,9 @@ See [SVG Accessibility Best Practices](examples/SVG_ACCESSIBILITY_BEST_PRACTICES
 
 See:
 
-- [Mermaid Accessibility Best Practices](examples/MERMAID_ACCESSIBILITY_BEST_PRACTICES.md)
-- [Mermaid Diagram Types](examples/MERMAID_DIAGRAM_TYPES.md)
-- [Mermaid Transformation Best Practices](examples/MERMAID_TRANSFORMATION_BEST_PRACTICES.md)
+- [Mermaid Accessibility Best Practices](MERMAID_ACCESSIBILITY_BEST_PRACTICES.md)
+- [Mermaid Diagram Types](MERMAID_DIAGRAM_TYPES.md)
+- [Mermaid Transformation Best Practices](MERMAID_TRANSFORMATION_BEST_PRACTICES.md)
 
 ### Transformation provenance
 
@@ -393,7 +393,7 @@ Choose checks based on impact and risk:
 - screen reader reading and interaction for representative tasks; and
 - final generated, embedded, print, raster, SVG, and PDF output.
 
-See the [Manual Accessibility Testing Guide](examples/MANUAL_ACCESSIBILITY_TESTING_GUIDE.md).
+See the [Manual Accessibility Testing Guide](MANUAL_ACCESSIBILITY_TESTING_GUIDE.md).
 
 ### Test inventory
 
@@ -462,7 +462,7 @@ Useful details include:
 
 Project responders must offer another reporting route if the issue form itself
 is inaccessible. See
-[Accessibility Bug Reporting Best Practices](examples/ACCESSIBILITY_BUG_REPORTING_BEST_PRACTICES.md).
+[Accessibility Bug Reporting Best Practices](ACCESSIBILITY_BUG_REPORTING_BEST_PRACTICES.md).
 
 ## 12. Severity, Priority, and Response
 
@@ -552,7 +552,7 @@ Contributors and agents must:
   HTML, labels, URLs, and generated artifacts as potentially untrusted input;
 - follow repository authority and security boundaries;
 - use normative and authoritative sources for requirements;
-- check [Trusted Sources](examples/TRUSTED_SOURCES.yaml) and respect source
+- check [Trusted Sources](TRUSTED_SOURCES.yaml) and respect source
   licensing, attribution, and stated AI-use restrictions;
 - verify generated code in the final user experience;
 - never invent user research, manual testing, assistive technology results,
@@ -597,10 +597,10 @@ Review this file:
 
 ### Project guidance
 
-- [Contributing Accessibility Guide](examples/CONTRIBUTING_A11Y.md)
-- [Manual Accessibility Testing Guide](examples/MANUAL_ACCESSIBILITY_TESTING_GUIDE.md)
-- [Accessibility Bug Reporting Best Practices](examples/ACCESSIBILITY_BUG_REPORTING_BEST_PRACTICES.md)
-- [Trusted Sources](examples/TRUSTED_SOURCES.yaml)
+- [Contributing Accessibility Guide](CONTRIBUTING_A11Y.md)
+- [Manual Accessibility Testing Guide](MANUAL_ACCESSIBILITY_TESTING_GUIDE.md)
+- [Accessibility Bug Reporting Best Practices](ACCESSIBILITY_BUG_REPORTING_BEST_PRACTICES.md)
+- [Trusted Sources](TRUSTED_SOURCES.yaml)
 
 ### Standards and evaluation
 
@@ -642,4 +642,4 @@ Before adopting this template:
 
 ---
 
-This template is available under the repository's [MIT License](LICENSE).
+This template is available under the repository's [MIT License](../LICENSE).

--- a/examples/CONTRIBUTING_A11Y.md
+++ b/examples/CONTRIBUTING_A11Y.md
@@ -55,7 +55,7 @@ These answers determine the required implementation guidance and testing.
 
 ### 2. Find the applicable guidance
 
-Start with [ACCESSIBILITY-template.md](../ACCESSIBILITY-template.md), then use the topic-specific guides in this directory. Do not copy a pattern without reading its limitations and testing guidance.
+Start with [ACCESSIBILITY-template.md](ACCESSIBILITY-template.md), then use the topic-specific guides in this directory. Do not copy a pattern without reading its limitations and testing guidance.
 
 When adding or revising factual guidance:
 
@@ -488,7 +488,7 @@ Avoid these recurring mistakes:
 
 ## Related References
 
-- [ACCESSIBILITY-template.md](../ACCESSIBILITY-template.md)
+- [ACCESSIBILITY-template.md](ACCESSIBILITY-template.md)
 - [Root Contributing Guide](../CONTRIBUTING.md)
 - [Examples Index](./README.md)
 - [Manual Accessibility Testing Guide](./MANUAL_ACCESSIBILITY_TESTING_GUIDE.md)

--- a/examples/COPILOT_BOOTSTRAP_AGENT_PROMPT.md
+++ b/examples/COPILOT_BOOTSTRAP_AGENT_PROMPT.md
@@ -6,7 +6,7 @@ last_reviewed: 2026-07-19
 # Copilot Bootstrap Prompt
 
 This file provides a reusable task prompt for drafting a project-level
-`ACCESSIBILITY.md` from [ACCESSIBILITY-template.md](../ACCESSIBILITY-template.md).
+`ACCESSIBILITY.md` from [ACCESSIBILITY-template.md](ACCESSIBILITY-template.md).
 It can be used with GitHub Copilot cloud agent or another agent that can inspect
 the target repository.
 
@@ -263,7 +263,7 @@ resulting diff, tests, and human reviewer findings.
 
 ## Related Files
 
-- [ACCESSIBILITY.md template](../ACCESSIBILITY-template.md)
+- [ACCESSIBILITY.md template](ACCESSIBILITY-template.md)
 - [Repository agent instructions](../AGENTS.md)
 - [Copilot Agent Guide](./COPILOT_AGENT_MODE_GUIDE.md)
 - [Manual Accessibility Testing](./MANUAL_ACCESSIBILITY_TESTING_GUIDE.md)

--- a/examples/MERMAID_TRANSFORMATION_BEST_PRACTICES.md
+++ b/examples/MERMAID_TRANSFORMATION_BEST_PRACTICES.md
@@ -992,7 +992,7 @@ A Mermaid transformation is ready for production when:
 
 - [Content Security Policy Level 3](https://www.w3.org/TR/CSP3/)
 - [DOMPurify](https://github.com/cure53/DOMPurify)
-- [SVGO Documentation](https://svgo.dev/docs/)
+- [SVGO Documentation](https://svgo.dev/docs/introduction/)
 - [OWASP XML External Entity Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html)
 
 ### Machine-Readable References

--- a/examples/SVG_ACCESSIBILITY_BEST_PRACTICES.md
+++ b/examples/SVG_ACCESSIBILITY_BEST_PRACTICES.md
@@ -945,7 +945,7 @@ dependency version, or embedding path changes.
 - [CSS Color Adjustment Module Level 1](https://www.w3.org/TR/css-color-adjust-1/)
 - [Content Security Policy Level 3](https://www.w3.org/TR/CSP3/)
 - [DOMPurify](https://github.com/cure53/DOMPurify)
-- [SVGO Documentation](https://svgo.dev/docs/)
+- [SVGO Documentation](https://svgo.dev/docs/introduction/)
 - [OWASP XML External Entity Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html)
 - [Understanding 1.1.1: Non-text Content](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html)
 - [Understanding 1.4.11: Non-text Contrast](https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html)


### PR DESCRIPTION
## Summary
- Fixes the `markdown-links` job of the Link Check workflow, which has been failing on `main`.
- Most failures were the same pattern: a file inside `examples/` linked to another `examples/` file using a repo-root-relative path (`examples/FOO.md`) instead of a same-directory path (`FOO.md`), doubling to `examples/examples/FOO.md` and 404ing. Fixed in `examples/ACCESSIBILITY-template.md` (15 links) and `examples/CONTRIBUTING_A11Y.md` / `examples/COPILOT_BOOTSTRAP_AGENT_PROMPT.md` (which had the opposite problem — an extra unneeded `../` pointing to `ACCESSIBILITY-template.md`, which actually lives in the same directory).
- Root-level files (`README.md`, `ACCESSIBILITY.md`) linked to `ACCESSIBILITY-template.md` without the `examples/` prefix, but that file lives in `examples/`. Fixed both.
- `examples/ACCESSIBILITY-template.md` also had two links (`CONTRIBUTING.md`, `LICENSE`) missing a `../` since those files live at the repo root, not in `examples/`.
- Updated the dead `https://svgo.dev/docs/` link (404) to the current `https://svgo.dev/docs/introduction/` in two files.

## Test plan
- [x] Installed `lychee` 0.24.2 locally (matching the CI action's pinned version).
- [x] Ran `lychee --verbose --no-progress --max-retries 2 --retry-wait-time 2 --timeout 20 --config .github/lychee.toml "README.md" "examples/**/*.md"` against a clean `git archive` checkout of this branch (to exactly mirror the CI checkout, since local `node_modules/` would otherwise introduce unrelated noise) — **0 Errors**.

AI-assisted: yes
Tool used: Claude Code
External code copied: no
External sources consulted: svgo.dev (to find current docs URL)
Copyright concern: none known

🤖 Generated with [Claude Code](https://claude.com/claude-code)