### PR TITLE
Fix leftover AI text, broken links, a missing section, and a config key the style guide points at

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in improving ACCESSIBILITY.md.
 
 We welcome contributions from the community, especially from people with disabilities (PwD) and others with lived accessibility experience. Your feedback helps ensure this project remains practical, inclusive, and grounded in real-world use.
 
-For project accessibility standards and requirements, see [ACCESSIBILITY-template.md](./ACCESSIBILITY-template.md), which provides the framework this repository follows.
+For project accessibility standards and requirements, see [ACCESSIBILITY-template.md](./examples/ACCESSIBILITY-template.md), which provides the framework this repository follows.
 
 > [!IMPORTANT]
 > **Participation from people with disabilities is highly valued in this project.**
@@ -33,7 +33,7 @@ For project accessibility standards and requirements, see [ACCESSIBILITY-templat
 - Link related issues where possible.
 - Update relevant docs in [examples/](examples/) when introducing new guidance.
 - Ensure documentation links pass repository link checks.
-- Follow the accessibility standards outlined in [ACCESSIBILITY-template.md](./ACCESSIBILITY-template.md).
+- Follow the accessibility standards outlined in [ACCESSIBILITY-template.md](./examples/ACCESSIBILITY-template.md).
 - If proposing code examples, ensure they meet WCAG 2.2 AA standards.
 - Consider testing with assistive technologies when relevant (screen readers, keyboard navigation, etc.).
 

--- a/README.md
+++ b/README.md
@@ -379,7 +379,3 @@ We are looking for feedback on the taxonomy and automation workflows.
 ## 📄 License
 
 This project is licensed under the [MIT License](./LICENSE).
-
----
-
-**Would you like me to generate a sample `specification.md` next to define the exact Markdown headings and data structures for this standard?**

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Just as `SECURITY.md` defines how to handle vulnerabilities, **`ACCESSIBILITY.md`** defines the inclusive state of a project. It is a human and machine-readable manifest that tracks a project’s commitment to accessibility (a11y) through metrics, guardrails, and automated enforcement.
 
-> **Looking for the Claude Skills approach?** If you want to add accessibility guidance to a project via an `AGENTS.skills`, see the companion repo: **[mgifford/accessibility-skills](https://github.com/mgifford/accessibility-skills/) (now with evals)**.
+> **Looking for the Claude Skills approach?** If you want to add accessibility guidance to a project as installable agent skills, see the companion repo: **[mgifford/accessibility-skills](https://github.com/mgifford/accessibility-skills/) (now with evals)**.
 
 ---
 
@@ -46,16 +46,17 @@ This repository is organized to separate **content you adopt** from **project do
 
 ```
 [Repository Root]
-├── ACCESSIBILITY-template.md       ← Start here: Copy this template
 ├── ACCESSIBILITY.md                ← Our own accessibility commitment
 ├── AGENTS.md                       ← AI agent instructions (copy/adapt)
 ├── CONTRIBUTING.md                 ← How to contribute to this project
+├── STYLES.md                       ← Design and content standards
 ├── SUSTAINABILITY.md               ← Sustainability policy
 ├── BROWSER_SUPPORT.md              ← Browser support guidelines
 ├── COMPARISONS.md                  ← Comparison with similar projects
 ├── README.md                       ← This file
 │
 ├── examples/                       ← Copy these to your project
+│   ├── ACCESSIBILITY-template.md             ← Start here: copy this template
 │   ├── A11Y_SHIFT_LEFT_WORKFLOW.yml          ← GitHub Actions workflow
 │   ├── PRE_COMMIT_ACCESSIBILITY_SAMPLE.yaml  ← Pre-commit hooks
 │   ├── TRUSTED_SOURCES.yaml                  ← Vetted a11y resources
@@ -191,8 +192,6 @@ Learn more: [SHIFT_LEFT_ACCESSIBILITY_AUTOMATION.md](./examples/SHIFT_LEFT_ACCES
 ### Step 3: Configure AI coding assistants
 
 Help your AI tools (GitHub Copilot, Cursor, Claude, Codex, etc.) respect accessibility standards:
-
-**For project-level configuration:**
 
 **For Cursor or similar tools:**
 1. Copy [AGENTS.md](./AGENTS.md) to your repository root
@@ -349,7 +348,7 @@ This section documents which AI tools have been used in the development and main
 
 - **Runtime AI**: None. This is a static documentation project; no AI is invoked when users read or use the files.
 - **Browser-based AI**: None. No client-side or browser-based AI features are embedded in this project.
-- **Human oversight**: All AI-generated content is reviewed by the repository maintainer before merging. The README already notes: *"Most of the content on this site was generated with AI assistance and has not yet been fully validated in real-world conditions."*
+- **Human oversight**: All AI-generated content is reviewed by the repository maintainer before merging. The warning at the top of this file notes: *"Most of the content on this site was generated with AI assistance and has not yet been fully validated in real-world conditions."*
 
 ### How to update this disclosure
 

--- a/STYLES.md
+++ b/STYLES.md
@@ -195,9 +195,7 @@ Always honor CSS media query preferences before adding JavaScript-driven control
 
 See also: `ACCESSIBILITY.md`, and the [User Personalization Best Practices](examples/USER_PERSONALIZATION_ACCESSIBILITY_BEST_PRACTICES.md) guide for JavaScript-driven preference controls.
 
----
-
-## 3.5 Page layout patterns
+### 3.5 Page layout patterns
 
 The site uses two layout templates defined in `_layouts/`:
 
@@ -206,7 +204,7 @@ The site uses two layout templates defined in `_layouts/`:
 | `default` | `_layouts/default.html` | Home page and pages with custom full-width HTML sections (hero, cards, steps) |
 | `prose` | `_layouts/prose.html` | All markdown-rendered content pages (guides in `examples/`, reference docs) |
 
-### Prose layout
+#### Prose layout
 
 Apply `layout: prose` (set automatically via `_config.yml` for `examples/`) to any page whose content is rendered from Markdown. The `prose` layout:
 
@@ -216,7 +214,7 @@ Apply `layout: prose` (set automatically via `_config.yml` for `examples/`) to a
 
 > **AI agents:** When creating a new Markdown guide in `examples/`, do **not** add `layout:` to the file's front matter — the `_config.yml` scope rule applies `prose` automatically.
 
-### Code-card pattern
+#### Code-card pattern
 
 The `.code-card` component on the home page follows this padding convention:
 
@@ -231,8 +229,7 @@ All three children share horizontal padding of `1rem` to keep text flush with th
 ---
 
 ## 4. Accessibility and semantic logic
-This section implements the mandates in `ACCESSIBILITY.md` [[ACCESSIBILITY.md]],
-
+This section implements the mandates in [ACCESSIBILITY.md](ACCESSIBILITY.md).
 
 * **Heading Hierarchy:** Must be logical. H1 → H2 → H3. Never skip levels for "style."
 * **Alt-Text:** Must describe the *intent* of the image, not just the pixels. 
@@ -248,7 +245,7 @@ This section implements the mandates in `ACCESSIBILITY.md` [[ACCESSIBILITY.md]],
 3. **Reference Accessibility:** Before outputting a UI component, check `ACCESSIBILITY.md` for ARIA and keyboard navigation requirements.
 4. **Markdown Formatting:** Always use semantic Markdown. Use GFM (GitHub Flavored Markdown) callouts (`> [!NOTE]`) for emphasis.
 
-Also see: [[AGENTS.md]]
+Also see: [AGENTS.md](AGENTS.md)
 
 ---
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,8 @@
 title: ACCESSIBILITY.md
 description: The open standard for project accessibility transparency, governance, and AI-assisted inclusion.
+# Spelling variant and page language. See STYLES.md section 2.4.
+# Change this to en-GB or en-CA in a derived project to switch conventions.
+lang: en-US
 baseurl: "/ACCESSIBILITY.md"
 url: "https://mgifford.github.io"
 github_url: "https://github.com/mgifford/ACCESSIBILITY.md/"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="{{ site.lang | default: 'en' }}">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
Five fixes to root-level documentation. Everything here is something that is broken, missing, or points at something that does not exist.

Closes #142, closes #143, closes #145, closes #146.

## 1. The README ended with a leftover AI chat turn

```
**Would you like me to generate a sample `specification.md` next to define
the exact Markdown headings and data structures for this standard?**
```

Bolded, under the License heading, as the last thing on the landing page. Because it is in second person it reads as though the project is asking the visitor a question.

I swept the rest of the repository against a set of common assistant sign-off phrasings — this is the only occurrence, so it is a one-off paste rather than a pattern. (#142)

## 2. Three references send people to a template that is not there

`ACCESSIBILITY-template.md` lives in `examples/`, but:

- `CONTRIBUTING.md:7` and `:36` link to `./ACCESSIBILITY-template.md` — both 404
- the README's structure tree lists it under `[Repository Root]`

Quick start step 1 is "Copy the template," so this lands on new adopters at their first interaction with the project. (#143)

## 3. A section with its content missing

Step 3 has `**For project-level configuration:**` with nothing beneath it, immediately followed by another bold lead-in. (#146)

## 4. `AGENTS.skills` does not exist

The README's second paragraph points people at `AGENTS.skills` to adopt the companion project. That filename is not in this repository or in `accessibility-skills`, which distributes `.skill` archives. Reworded to "installable agent skills" — you will know the intended term better than I do. (#146)

## 5. STYLES.md points at a config key that was never added

§2.4 instructs agents to "always check the `lang` attribute at the top of `_config.yml`." There was no `lang` key, so an agent following that instruction found nothing. `_layouts/default.html` separately hardcoded `<html lang="en">`, so the two files §2.4 describes as needing to stay in sync were not connected.

Added `lang: en-US` and wired the layout to read it. (#145)

Also in STYLES.md: `[[ACCESSIBILITY.md]]` and `[[AGENTS.md]]` are Obsidian wikilinks that render as literal double brackets on GitHub and Pages, so neither was ever a link; and `## 3.5` sat at H2 among H3 siblings, which §4 of that same file forbids. (#145)

## Two calls left to you

**The `lang` commit is functional, not documentation.** It is isolated so you can drop it and keep the rest.

**The CONTRIBUTING.md links may want a different target, not just a fixed path.** Line 7 calls the target "the framework this repository follows" and line 36 "the accessibility standards" to follow. Both read more naturally as `ACCESSIBILITY.md` than as the reusable template — a distinction `ACCESSIBILITY.md` §1 draws explicitly. I corrected the path only.

## Scope

5 files, +15/−20. I deliberately kept out anything that was a preference rather than a defect — an earlier version of this PR also recased headings for STYLES.md compliance and normalised spellings, and I have dropped all of it as churn that was not worth your review time (#144 closed accordingly).

I read through `examples/` while checking this and did not touch it. The guidance there is technically sound — `MAPS_ACCESSIBILITY_BEST_PRACTICES.md` even flags the 24×24 vs 44×44 Level AA misconception as a common failure, which is a mistake plenty of published guidance makes. The problems were confined to the root-level meta-documentation.

## Verification

- Audited every relative Markdown link in the repo (70 files) against the filesystem. The two in `CONTRIBUTING.md` were the only genuine breaks; the remaining flags are Jekyll `.html` output paths that resolve on the built site.
- Confirmed no workflow, script, or schema depends on anything changed here.