### PR TITLE
docs(agents): add upstream-first ownership step and human-approval gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,21 @@ Identify:
 Use the likelihood and consequence of a regression to decide how much testing
 and review is needed.
 
-### 3. Find applicable guidance
+### 3. Decide the responsible source
+
+Before implementing a fix for a barrier that may originate in a shared
+component, design system, renderer, or external dependency, load the
+[Upstream First](https://github.com/mgifford/upstream-first) skill to decide
+whether the responsible change is local, an existing installed capability, or
+an upstream contribution. Use `maintainer-ready-contribution` to prepare an
+upstream submission. Do not open, comment on, or submit anything in an
+external project without explicit human approval. Record any temporary local
+divergence in the
+[downstream divergence record](examples/ACCESSIBILITY-template.md#temporary-downstream-divergence-record)
+and do not describe a merged upstream fix as resolved until it is released,
+adopted, and verified.
+
+### 4. Find applicable guidance
 
 Use primary standards for requirements and project guides for implementation
 and testing.
@@ -184,6 +198,7 @@ and testing.
 - [CI/CD Accessibility](examples/CI_CD_ACCESSIBILITY_BEST_PRACTICES.md)
 - [Shift-Left Automation](examples/SHIFT_LEFT_ACCESSIBILITY_AUTOMATION.md)
 - [Progressive Enhancement](examples/PROGRESSIVE_ENHANCEMENT_BEST_PRACTICES.md)
+- [Upstream First](https://github.com/mgifford/upstream-first) — decision skill for whether a barrier's responsible fix is local, an installed capability, or an upstream contribution; use `maintainer-ready-contribution` for the submission itself. This repository does not restate that decision hierarchy; see [the template's divergence record](examples/ACCESSIBILITY-template.md#temporary-downstream-divergence-record) for tracking temporary local patches.
 
 ### Interaction and navigation
 
@@ -488,9 +503,12 @@ Stop and request direction when:
 - a third-party source restriction prevents necessary verification;
 - required credentials, devices, assistive technologies, or environments are
   unavailable and the missing evidence is release-critical;
-- a secure implementation cannot be provided within scope; or
+- a secure implementation cannot be provided within scope;
 - current user changes overlap the requested edit and cannot be preserved
-  safely.
+  safely; or
+- a fix would require opening, commenting on, or submitting anything in an
+  external project (an issue, fork, branch, or pull request) without prior
+  human approval.
 
 Do not stop solely because:
 
@@ -579,6 +597,12 @@ Use this structure in a pull request or final task report:
 ## Not tested or known limitations
 
 -
+
+## Source ownership and upstream status
+
+- Responsible source (local, integration, dependency, or ecosystem):
+- Upstream reference, if any:
+- Temporary downstream divergence recorded, if any:
 
 ## Sources
 


### PR DESCRIPTION
## Summary

PR 2 of the upstream-first adoption plan (follows #148, merged). Adds a pointer from `AGENTS.md` to the [upstream-first](https://github.com/mgifford/upstream-first) skill so agents decide ownership before implementing a fix, rather than defaulting to a local patch.

- New step 3, "Decide the responsible source," under **Before Making Changes**: load `upstream-first` before fixing a barrier that may originate in a shared component/dependency, use `maintainer-ready-contribution` for the submission, and record temporary divergence in the template's divergence record (added in #148). Existing step 3 ("Find applicable guidance") renumbered to 4.
- New entry in the **Topic Guide Routing** table pointing at `upstream-first`, explicitly noting this repo does not restate its decision hierarchy.
- New hard-stop condition in **Stop or Escalate When**: never open, comment on, or submit anything in an external project without prior human approval — mirrors `upstream-first`'s own guardrail.
- New **Source ownership and upstream status** fields in the **Required Handoff** template (responsible source, upstream reference, divergence recorded).

Deliberately not included: restating `upstream-first`'s classification dimensions, 6-option hierarchy, or engagement-path selection — those stay owned by that skill and are linked, not duplicated.

## Test plan

- [x] Diff reviewed: single file, +27/-3, no unrelated changes.
- [x] Step renumbering (3→4) checked for stale cross-references elsewhere in the repo — none found.
- [x] New anchor link (`examples/ACCESSIBILITY-template.md#temporary-downstream-divergence-record`) confirmed to resolve against the heading added in #148.
- [ ] Link Check CI should pass — only new links are one external URL (repeated twice) and one internal anchor already verified above.

AI-assisted: yes
Tool used: Claude Code
External code copied: no
External sources consulted: mgifford/upstream-first README and SKILL.md (for pointer wording only, no content copied verbatim)
Copyright concern: none known