### PR TITLE
docs(finding-tracking): document local and upstream tracker relationships

### DIFF
--- a/examples/ACCESSIBILITY_FINDING_TRACKING.md
+++ b/examples/ACCESSIBILITY_FINDING_TRACKING.md
@@ -93,6 +93,38 @@ https://jira.example.org/browse/A11Y-142
 
 Do not invent a tracker ID where no tracked work item exists.
 
+#### Local and upstream trackers
+
+`tracking.tracker_ids` is an array: a finding may carry both a local
+remediation tracker and an upstream tracker in the project that owns the
+affected component or dependency, using
+[Upstream First](https://github.com/mgifford/upstream-first) to decide
+whether an upstream contribution is warranted. Each entry's `relationship`
+and `status` (or `tracker_native_status`) describe that entry alone — an
+upstream tracker's status is never inferred onto the local tracker, or onto
+the finding's own lifecycle state.
+
+```json
+"tracker_ids": [
+  {
+    "id": "https://github.com/example/product/issues/482",
+    "relationship": "tracks",
+    "status": "open"
+  },
+  {
+    "id": "https://github.com/example/design-system/issues/91",
+    "relationship": "blocked-by",
+    "status": "closed",
+    "tracker_native_status": "merged, unreleased"
+  }
+]
+```
+
+A closed or merged upstream tracker is not evidence that the finding is
+`resolved`. Resolution still requires the affected user task to be retested
+after the upstream correction is released and adopted downstream; see
+[Resolved](#resolved) below.
+
 ### Occurrence fingerprint
 
 A deterministic, versioned correlation key for a pattern at a normalized resource, route pattern, or component state. It is computed rather than assigned.
@@ -220,6 +252,13 @@ The prior occurrence is outside the explicitly defined current comparison scope.
 ### Resolved
 
 Use only when the relevant scope was successfully retested or explicitly verified and the project's closure criteria have been met. An automated rule no longer reporting a result is not sufficient evidence by itself.
+
+When a finding's fix depends on an upstream tracker (see
+[Local and upstream trackers](#local-and-upstream-trackers)), an upstream
+issue being closed or a pull request being merged is not sufficient evidence
+either. Move to `resolved` only after the upstream correction has been
+released, adopted by this project (dependency upgraded, patch removed), and
+the original user task has been retested.
 
 ## Policy Classification
 
@@ -454,3 +493,4 @@ This guide does not change either implementation.
 - [Accessibility Bug Reporting Best Practices](./ACCESSIBILITY_BUG_REPORTING_BEST_PRACTICES.md)
 - [Contributing Accessibility Guide](./CONTRIBUTING_A11Y.md)
 - [Examples Index](./README.md)
+- [Upstream First](https://github.com/mgifford/upstream-first) - decision skill for whether a root cause's responsible fix is local, an installed capability, or an upstream contribution; see [Local and upstream trackers](#local-and-upstream-trackers) above for recording the relationship on a finding


### PR DESCRIPTION
## Summary

PR 3 of the upstream-first adoption plan (follows #148 and #149, both merged). Documents how the existing finding schema already supports recording both a local remediation tracker and an upstream tracker for the same finding — no schema or enum change.

- New subsection **Local and upstream trackers** under the existing "Tracker ID" term: `tracking.tracker_ids` is already an array of `trackerRelationship` objects, each with its own independent `relationship`/`status`/`tracker_native_status`. A worked example shows one `tracks` (local) entry and one `blocked-by` (upstream) entry side by side.
- Strengthened **Resolved** lifecycle state: an upstream issue closing or a PR merging is explicitly *not* sufficient evidence — resolution requires the upstream correction to be released, adopted downstream, and the original user task retested.
- One **Related Guides** link to [upstream-first](https://github.com/mgifford/upstream-first) for the ownership decision itself.

Verified before writing this: `examples/schemas/accessibility-finding-v2.schema.json`'s `tracker_ids` is already `type: array` of `trackerRelationship`, and each relationship entry already carries independent `status`/`tracker_native_status` fields — so this is documentation of existing capability, not new schema surface. Confirmed by rerunning `cd examples/schemas && node validate-accessibility-findings.mjs` after this change (still passes, unaffected since no schema/example file was touched).

Deliberately **not** included in this PR (kept separate to avoid scope creep):
- Adding a local+upstream `tracker_ids` pair to `accessibility-finding-v2.example.json` — a good follow-up, but a distinct, reviewable change to a schema example file rather than a docs-only change.
- Any change to `examples/schemas/README.md` — that file explicitly defers terminology to this guide already, so duplicating the explanation there would violate its own stated division of labor.
- Any change to the `lifecycle` enum, fingerprint profiles, or `root_cause_id` definition — the latter already correctly covers "shared component... dependency" as a valid root-cause source and didn't need editing.

## Test plan

- [x] Diff reviewed: single file, +40/-0, documentation only.
- [x] New anchors (`#local-and-upstream-trackers`) resolve; existing `#resolved` anchor still resolves after the edit.
- [x] `cd examples/schemas && node validate-accessibility-findings.mjs` still passes (schema compiles, 3 valid examples, 8 policy examples, 1 shared fixture, 13 invalid-as-expected).
- [ ] Link Check CI should pass — only new link is one external URL and one internal anchor, both verified above.

AI-assisted: yes
Tool used: Claude Code
External code copied: no
External sources consulted: mgifford/upstream-first README (for pointer wording only); this repo's own accessibility-finding-v2.schema.json (read, not modified)
Copyright concern: none known