### PR TITLE
docs(nav): add upstream-first navigation mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ An effective `ACCESSIBILITY.md` file acts as a **Living Commitment**, covering t
 * **Taxonomy:** Standardized labels for issues (e.g., `accessibility`, `color-contrast`).
 * **Definition of Done:** Requirement that no PR is merged without passing a11y linting.
 * **Severity Matrix:** How a11y bugs are prioritized compared to feature requests.
+* **Upstream-first responsibility:** Determine where a barrier originates (local code, a shared component, or a dependency), contribute reusable corrections to the responsible project when viable, and track any temporary local fix until it is released, adopted, and verified. See [Upstream First](https://github.com/mgifford/upstream-first) and the [downstream divergence record](./examples/ACCESSIBILITY-template.md#temporary-downstream-divergence-record).
 
 ### 3. Automated guardrails (the AI bridge)
 * **CI/CD Integration:** Links to workflows running `axe-core` or `Lighthouse`.
@@ -374,6 +375,7 @@ We are looking for feedback on the taxonomy and automation workflows.
 - [Accessibility Agents](https://github.com/Community-Access/accessibility-agents)
 - [Awesome Copilot A11y Instructions](https://github.com/github/awesome-copilot/blob/main/instructions/a11y.instructions.md)
 - [AccessLint skills](https://github.com/AccessLint/skills)
+- [Upstream First](https://github.com/mgifford/upstream-first) - agent skills for deciding whether a fix belongs locally, upstream, or in an existing dependency
 
 ## 📄 License
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -69,6 +69,7 @@ Reference and adapt these examples for your project — they are not copy-paste 
 
 - [CONTRIBUTING_A11Y](./CONTRIBUTING_A11Y.md)
 - [COPILOT_AGENT_MODE_GUIDE](./COPILOT_AGENT_MODE_GUIDE.md)
+- [Upstream First](https://github.com/mgifford/upstream-first) - decision skill for whether a barrier's responsible fix is local, an installed capability, or an upstream contribution; see the [template's divergence record](./ACCESSIBILITY-template.md#temporary-downstream-divergence-record) for tracking temporary local patches
 
 ## YAML / Workflow Assets
 

--- a/index.md
+++ b/index.md
@@ -126,7 +126,9 @@ full_width: true
         <h3>Operational Governance</h3>
         <p>
           Define issue taxonomy, severity triage, and accessibility Definition of
-          Done.
+          Done. Decide whether a barrier's fix belongs locally or upstream with
+          <a href="https://github.com/mgifford/upstream-first">Upstream First</a>,
+          and track any temporary local fix until it is released and verified.
         </p>
       </article>
       <article class="card">
@@ -380,6 +382,10 @@ full_width: true
         <a href="https://github.com/mgifford/accessibility-skills"><strong>accessibility-skills</strong></a>.
         Topic-specific <code>.skill</code> archives (forms, keyboard, maps, SVG, and more) are available
         there for global installation in Claude Code, Codex, and other AI coding assistants.
+      </p>
+      <p>
+        For deciding whether a fix belongs locally, in an installed capability, or
+        upstream, see <a href="https://github.com/mgifford/upstream-first"><strong>Upstream First</strong></a>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Summary

PR 4 (final PR) of the upstream-first adoption plan (follows #148, #149, #150, all merged). Adds discoverability mentions across the three navigation surfaces: README.md, examples/README.md, and index.md.

- **README.md**: new bullet under "🛠 The framework" → "2. Operational governance" (the same category as taxonomy, Definition of Done, and severity matrix), plus a new entry in "Related Projects" alongside the other companion projects (`accessibility-skills`, `A11y.md`, etc.).
- **examples/README.md**: new entry under "Contributing and Guidance" alongside `CONTRIBUTING_A11Y` and `COPILOT_AGENT_MODE_GUIDE`.
- **index.md** (the built Jekyll landing page, which mirrors README's three-pillar framework as HTML cards): same addition to the "Operational Governance" card, plus a sentence in the "Skills" section alongside the existing `accessibility-skills` mention.

Every addition is a link plus one sentence — none restate `upstream-first`'s decision hierarchy, matching how `accessibility-skills` is already referenced in these same files ("AI agent skills have moved to a dedicated repository...").

## Test plan

- [x] Diff reviewed: 3 files, +10/-1 total, no unrelated changes.
- [x] Ran a full Jekyll build (`bundle exec jekyll build`) and confirmed both `index.md` additions render correctly in the built `index.html` (2 occurrences of "Upstream First" found in output, matching the two new mentions).
- [x] Checked `index.md`'s pre-existing `<p>`/`</p>` tag-count asymmetry (55/58 before this change, 56/59 after) — confirmed pre-existing and unrelated to this change; my one added `<p>...</p>` pair is balanced.
- [ ] Link Check CI should pass — only new links are external URLs and one already-verified internal anchor (`examples/ACCESSIBILITY-template.md#temporary-downstream-divergence-record`, added in #148).

This completes the 4-PR upstream-first adoption plan: #148 (template hook + divergence record), #149 (AGENTS.md ownership step + human-approval gate), #150 (finding-tracking local/upstream tracker docs), and this PR (navigation).

AI-assisted: yes
Tool used: Claude Code
External code copied: no
External sources consulted: none beyond this repository's own files
Copyright concern: none known