### PR TITLE
docs(playbook): correct Lighthouse-as-WCAG-conformance claims

### DIFF
--- a/action-playbook.md
+++ b/action-playbook.md
@@ -25,15 +25,14 @@ It is intentionally practical: short checklists, clear ownership, and measurable
 ### Phase 1: Starter commitment + CI gates first
 
 - Publish a short public commitment in `ACCESSIBILITY.md`.
-- Enforce CI gates for accessibility checks and WCAG compliance on every PR.
-- Run axe-core or Lighthouse on every PR against the live site URL.
-- Start with realistic thresholds (for example 95+ accessibility score) to catch meaningful issues while stabilizing signal quality.
+- Run axe-core or Lighthouse on every PR against the live site URL as an early indicator, not a conformance gate. A Lighthouse accessibility score is not a WCAG conformance result; it does not test keyboard operation, focus order, or assistive technology behavior.
+- Start with a realistic warning threshold (for example this repository's own `minScore: 0.9` accessibility score in [`.lighthouserc.json`](.lighthouserc.json)) to catch meaningful issues while stabilizing signal quality, before treating any threshold as a merge-blocking gate.
 
 ### Phase 2: Full template adoption after ownership is clear
 
 - Add full sections for ownership, scope, exceptions, and governance.
 - Establish metric baselines and monthly targets per owner.
-- Tighten CI and Lighthouse gates progressively toward 100/100/100/100 (Performance/Accessibility/Best Practices/SEO).
+- Tighten automated thresholds progressively as reviewed regressions are resolved. Raise a warning to a blocking gate only for a specific, deterministic, confirmed failure — never for an aggregate score across categories a tool does not test for WCAG conformance.
 
 ## Weekly workflow (team)
 
@@ -53,10 +52,10 @@ It is intentionally practical: short checklists, clear ownership, and measurable
 
 ### 3) Review with an accessibility gate
 
-- Verify no accessibility regressions in CI for WCAG compliance, keyboard navigation, or screen reader support.
+- Verify no confirmed regressions in automated accessibility checks, and confirm keyboard navigation and screen reader support with manual testing where automated coverage cannot verify them.
 - Require explicit justification for complex ARIA patterns when semantic HTML suffices.
-- Block merges when accessibility thresholds regress beyond agreed limits.
-- Review axe-core or Lighthouse trendlines each month and ratchet thresholds upward.
+- Block merges only on confirmed, deterministic failures against a reviewed baseline; treat an aggregate score drop as an indicator to investigate, not an automatic block.
+- Review axe-core or Lighthouse trendlines each month and ratchet warning thresholds upward as issues are resolved.
 
 ## Monthly cadence (team)
 


### PR DESCRIPTION
## Summary

Unrelated to the upstream-first work — this fixes stale, incorrect language in `action-playbook.md` flagged during an earlier content audit. Not part of the upstream-first PR sequence (#148-#151).

**The problem:** `action-playbook.md` treated a Lighthouse accessibility score as if it were a WCAG conformance measure, and described CI behavior that doesn't match this repository's own configuration:

- "Enforce CI gates for accessibility checks and WCAG compliance on every PR" — `.github/workflows/lighthouse.yml` only **warns**, it never blocks (`lhci autorun` with `"accessibility": ["warn", ...]` in `.lighthouserc.json`).
- "realistic thresholds (for example 95+ accessibility score)" — doesn't match this repo's own configured `minScore: 0.9` (90).
- "Tighten CI and Lighthouse gates progressively toward 100/100/100/100 (Performance/Accessibility/Best Practices/SEO)" — no such 4-category gate is configured anywhere; `.lighthouserc.json` only asserts on the `accessibility` category.
- "Verify no accessibility regressions in CI for WCAG compliance" and "Block merges when accessibility thresholds regress" — same conflation, plus claims a blocking behavior the workflow doesn't have.

This repo's own `AGENTS.md` already states the correct principle under "Existing automation": **"A Lighthouse score is not a conformance result."** This PR brings `action-playbook.md` in line with that and with the actual `.lighthouserc.json`/`lighthouse.yml` behavior, rather than inventing a stricter or more automated posture than exists.

**What I left alone:** the scorecard's "WCAG conformance level (A, AA, or AAA)" line (line 137) — that's a manually-evaluated metric being tracked, not a claim that Lighthouse produces it, so no conflation there.

## Test plan

- [x] Diff reviewed: single file, +6/-7, no unrelated changes.
- [x] Verified against actual repo config: `.lighthouserc.json` (`minScore: 0.9`, `accessibility` category only, `warn` not `error`) and `.github/workflows/lighthouse.yml` (never blocks, comment in the workflow itself says "Warns (does not fail)").
- [x] Cross-checked against `AGENTS.md`'s existing "A Lighthouse score is not a conformance result" statement for consistent repo voice.
- [x] Ran a full Jekyll build (`bundle exec jekyll build`) and confirmed `action-playbook.html` renders correctly, including the new `.lighthouserc.json` link.
- [ ] Link Check CI should pass — new link target (`.lighthouserc.json`) confirmed to exist at repo root.

AI-assisted: yes
Tool used: Claude Code
External code copied: no
External sources consulted: none beyond this repository's own files (.lighthouserc.json, lighthouse.yml, AGENTS.md)
Copyright concern: none known