### PR TITLE
docs(schemas): populate tracker_ids with local and upstream example

### DIFF
--- a/examples/schemas/accessibility-finding-v2.example.json
+++ b/examples/schemas/accessibility-finding-v2.example.json
@@ -17,7 +17,19 @@
     "raw_result_reference": null
   },
   "tracking": {
-    "tracker_ids": [],
+    "tracker_ids": [
+      {
+        "id": "https://github.com/example/product/issues/482",
+        "relationship": "tracks",
+        "status": "open"
+      },
+      {
+        "id": "https://github.com/example/payment-design-system/issues/91",
+        "relationship": "blocked-by",
+        "status": "closed",
+        "tracker_native_status": "merged, unreleased"
+      }
+    ],
     "fingerprints": {
       "a11y/pattern/v1": {
         "algorithm": "sha-256",


### PR DESCRIPTION
## Summary

Follow-up to #150. Populates the previously-empty `tracker_ids: []` in `examples/schemas/accessibility-finding-v2.example.json` with a worked local + upstream tracker pair, so the "complete" schema example actually demonstrates the pattern #150 documented in `ACCESSIBILITY_FINDING_TRACKING.md`.

- Local tracker: `relationship: "tracks"`, `status: "open"` — the product repo's own remediation issue.
- Upstream tracker: `relationship: "blocked-by"`, `status: "closed"`, `tracker_native_status: "merged, unreleased"` — an issue in a payment design-system repo whose merged-but-unreleased fix this finding depends on.

This fits the example's existing content rather than being bolted on: `scope.shared_component` is already `true` and `location.component` is `"Payment form"`, so a shared-component barrier having both a local remediation tracker and an upstream design-system tracker is consistent with the finding as already written — no other field needed to change.

No schema change. `tracker_ids` was already `type: array` of independent `trackerRelationship` objects (confirmed when writing #150); this only fills in the example.

## Test plan

- [x] Diff reviewed: single file, +13/-1, only the `tracker_ids` array populated.
- [x] `cd examples/schemas && node validate-accessibility-findings.mjs` passes: schema compiles, 3 valid examples, 8 policy examples, 1 shared fixture, 13 invalid-as-expected, and **the complete example's fingerprints still match Stage 2's frozen profiles** — confirming `tracker_ids` does not participate in fingerprint identity, consistent with the repo's existing invariant for `policy`.
- [x] Checked `examples/ACCESSIBILITY_BUG_REPORTING_BEST_PRACTICES.md`'s excerpt of this same finding (§18) — it already omits `tracking.tracker_ids` entirely (concise excerpt, not a full copy), so it does not go stale from this change.

AI-assisted: yes
Tool used: Claude Code
External code copied: no
External sources consulted: none beyond this repository's own schema and prior PR (#150)
Copyright concern: none known